### PR TITLE
bug fix: fix function deletion in smmh2.h, implement wrong

### DIFF
--- a/smmh2.h
+++ b/smmh2.h
@@ -122,7 +122,7 @@ void deletion(T* smmh,int idx,int& max_size){
 	smmh[idx] = smmh[--max_size];
 	int Y = idx;
 	while(1){
-		Y = adjust_sibling(smmh,Y,max_size);
+		adjust_sibling(smmh,Y,max_size);
 		int X = adjust_grandchild(smmh,Y,max_size);
 		if(X == Y)
 			break;


### PR DESCRIPTION
According to read code, the function deletion implied in smmh2.h is wrong.

When we are deleting node, the position index after we adjust sibling should not change.